### PR TITLE
Refactor config service to be project-level for simplicity

### DIFF
--- a/src/main/java/com/oddlyaccurate/poetryplugin/services/PoetryConfigService.java
+++ b/src/main/java/com/oddlyaccurate/poetryplugin/services/PoetryConfigService.java
@@ -1,12 +1,12 @@
 package com.oddlyaccurate.poetryplugin.services;
 
 import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleServiceManager;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents the current per-module configuration that the user has chosen for Poetry.
+ * Represents the current per-project configuration that the user has chosen for Poetry.
  * It provides access to this state through the `getState()` and `loadState()` methods.
  *
  * The state will be stored at some persistent location specified by the implementation.
@@ -14,12 +14,12 @@ import org.jetbrains.annotations.NotNull;
  * @see SimplePoetryConfigService
  */
 public interface PoetryConfigService extends PersistentStateComponent<PoetryConfigService.State> {
-    static PoetryConfigService getInstance(@NotNull Module module) {
-        return ModuleServiceManager.getService(module, PoetryConfigService.class);
+    static PoetryConfigService getInstance(@NotNull Project project) {
+        return ServiceManager.getService(project, PoetryConfigService.class);
     }
 
     /**
-     * Represents a actual module configuration of the poetry plugin.
+     * Represents a actual project configuration of the poetry plugin.
      */
     final class State implements Cloneable {
         /** The path to the desired poetry binary */

--- a/src/main/java/com/oddlyaccurate/poetryplugin/services/SimplePoetryConfigService.java
+++ b/src/main/java/com/oddlyaccurate/poetryplugin/services/SimplePoetryConfigService.java
@@ -1,13 +1,11 @@
 package com.oddlyaccurate.poetryplugin.services;
 
 import com.intellij.openapi.components.State;
-import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.components.StoragePathMacros;
 import org.jetbrains.annotations.NotNull;
 
 /** File-based implementation of the PoetryConfigService */
-@State(name = "PoetryPlugin", storages = @Storage(StoragePathMacros.MODULE_FILE))
-public class SimplePoetryConfigService implements PoetryConfigService {
+@State(name = "PoetryPlugin")
+public final class SimplePoetryConfigService implements PoetryConfigService {
     private PoetryConfigService.State state = new PoetryConfigService.State();
 
     @NotNull

--- a/src/main/java/com/oddlyaccurate/poetryplugin/ui/config/PoetryConfigurable.java
+++ b/src/main/java/com/oddlyaccurate/poetryplugin/ui/config/PoetryConfigurable.java
@@ -1,7 +1,7 @@
 package com.oddlyaccurate.poetryplugin.ui.config;
 
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.project.Project;
 import com.oddlyaccurate.poetryplugin.services.PoetryConfigService;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -15,7 +15,7 @@ import javax.swing.*;
  * Allows rendering the form, and integrates with OK/Apply/Cancel buttons
  * using fields below.
  */
-public class PoetryConfigurable implements Configurable {
+public final class PoetryConfigurable implements Configurable {
 
     /** The form specific to this module */
     private PoetryConfigForm configForm;
@@ -23,8 +23,8 @@ public class PoetryConfigurable implements Configurable {
     /** Our config service used for this module */
     private PoetryConfigService configService;
 
-    public PoetryConfigurable(@NotNull Module module) {
-        configService = PoetryConfigService.getInstance(module);
+    public PoetryConfigurable(@NotNull Project project) {
+        configService = PoetryConfigService.getInstance(project);
         configForm = new PoetryConfigForm(configService.getState());
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,10 +14,10 @@
     -->
 
     <extensions defaultExtensionNs="com.intellij">
-        <moduleService serviceInterface="com.oddlyaccurate.poetryplugin.services.PoetryConfigService"
-                       serviceImplementation="com.oddlyaccurate.poetryplugin.services.SimplePoetryConfigService"/>
-        <moduleConfigurable groupId="tools" displayName="Poetry" id="com.oddlyaccurate.poetryplugin.ui.config.PoetryConfigurable"
-                            instance="com.oddlyaccurate.poetryplugin.ui.config.PoetryConfigurable"/>
+        <projectService serviceInterface="com.oddlyaccurate.poetryplugin.services.PoetryConfigService"
+                        serviceImplementation="com.oddlyaccurate.poetryplugin.services.SimplePoetryConfigService"/>
+        <projectConfigurable groupId="tools" displayName="Poetry" id="com.oddlyaccurate.poetryplugin.ui.config.PoetryConfigurable"
+                             instance="com.oddlyaccurate.poetryplugin.ui.config.PoetryConfigurable"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
@kevinhyang 

While implementing Runner service, found that it's much simpler, if less flexible, to configure poetry's path per-project, so that our actions don't need to understand the current module scope.